### PR TITLE
Add cmd delete and backspace

### DIFF
--- a/front_end/cm/codemirror.js
+++ b/front_end/cm/codemirror.js
@@ -4856,6 +4856,12 @@
         return {from: Pos(range.from().line, 0), to: range.from()};
       });
     },
+    delLineRight: function(cm) {
+      deleteNearSelection(cm, function(range) {
+        var len = getLine(cm.doc, range.head.line).text.length;
+        return {from: range.from(), to: Pos(range.from().line, len)};
+      });
+    },
     delWrappedLineLeft: function(cm) {
       deleteNearSelection(cm, function(range) {
         var top = cm.charCoords(range.head, "div").top + 5;

--- a/front_end/source_frame/CodeMirrorTextEditor.js
+++ b/front_end/source_frame/CodeMirrorTextEditor.js
@@ -114,6 +114,7 @@ WebInspector.CodeMirrorTextEditor = function(url, delegate)
         "Cmd-Left": "goLineStartSmart",
         "Cmd-Right": "goLineEnd",
         "Cmd-Backspace": "delLineLeft",
+        "Cmd-Delete": "delLineRight",
         "Alt-Backspace": "delGroupBefore",
         "Alt-Delete": "delGroupAfter",
         "Cmd-/": "toggleComment",


### PR DESCRIPTION
Adds the text editor command `cmd-backspace`, which is a helpful way for deleting a line of text before the cursor. 

This could be inconsistent with windows, not sure whe conventions are there...
