### PR TITLE
Issue 472339: DevTools: provide affordance during recording

### DIFF
--- a/front_end/network/NetworkPanel.js
+++ b/front_end/network/NetworkPanel.js
@@ -152,7 +152,6 @@ WebInspector.NetworkPanel.prototype = {
     _createStatusbarButtons: function()
     {
         this._recordButton = new WebInspector.StatusBarButton("", "record-status-bar-item");
-        this._recordButton._glyphElement.classList.add("pulse"); /* Issue 472339: DevTools: provide affordance during recording */
         this._recordButton.addEventListener("click", this._onRecordButtonClicked, this);
         this._panelStatusBar.appendStatusBarItem(this._recordButton);
 

--- a/front_end/network/NetworkPanel.js
+++ b/front_end/network/NetworkPanel.js
@@ -152,6 +152,7 @@ WebInspector.NetworkPanel.prototype = {
     _createStatusbarButtons: function()
     {
         this._recordButton = new WebInspector.StatusBarButton("", "record-status-bar-item");
+        this._recordButton._glyphElement.classList.add("pulse"); /* Issue 472339: DevTools: provide affordance during recording */
         this._recordButton.addEventListener("click", this._onRecordButtonClicked, this);
         this._panelStatusBar.appendStatusBarItem(this._recordButton);
 

--- a/front_end/network/networkPanel.css
+++ b/front_end/network/networkPanel.css
@@ -256,3 +256,12 @@
     height: 100%;
     position: absolute;
 }
+
+@keyframes pulse-effect {
+    from {transform: scale(0.8);}
+    to {transform: scale(1.1);}
+}
+
+.network /deep/ button.record-status-bar-item.toggled-on .glyph {
+    animation: pulse-effect 2.5s infinite alternate ease-in-out ;
+}

--- a/front_end/network/networkPanel.css
+++ b/front_end/network/networkPanel.css
@@ -257,11 +257,6 @@
     position: absolute;
 }
 
-@keyframes pulse-effect {
-    from {transform: scale(0.8);}
-    to {transform: scale(1.1);}
-}
-
 .network /deep/ button.record-status-bar-item.toggled-on .glyph {
     animation: pulse-effect 2.5s infinite alternate ease-in-out ;
 }

--- a/front_end/ui/statusBar.css
+++ b/front_end/ui/statusBar.css
@@ -329,6 +329,15 @@ button.record-status-bar-item.toggled-on .glyph {
     background-color: rgb(216, 0, 0) !important;
 }
 
+@keyframes pulse-effect {
+    from {transform: scale(0.8);}
+    to {transform: scale(1.1);}
+}
+
+button.record-status-bar-item.toggled-on .pulse {
+    animation: pulse-effect 2.5s infinite alternate ease-in-out ;
+}
+
 .record-filmstrip-status-bar-item .glyph {
     -webkit-mask-position: -96px -24px;
 }

--- a/front_end/ui/statusBar.css
+++ b/front_end/ui/statusBar.css
@@ -329,15 +329,6 @@ button.record-status-bar-item.toggled-on .glyph {
     background-color: rgb(216, 0, 0) !important;
 }
 
-@keyframes pulse-effect {
-    from {transform: scale(0.8);}
-    to {transform: scale(1.1);}
-}
-
-button.record-status-bar-item.toggled-on .pulse {
-    animation: pulse-effect 2.5s infinite alternate ease-in-out ;
-}
-
 .record-filmstrip-status-bar-item .glyph {
     -webkit-mask-position: -96px -24px;
 }

--- a/front_end/ui/statusBar.css
+++ b/front_end/ui/statusBar.css
@@ -466,3 +466,8 @@ button.playback-rate-button {
     width: auto;
     margin-right: 10px;
 }
+
+@keyframes pulse-effect {
+    from {transform: scale(0.8);}
+    to {transform: scale(1.1);}
+}


### PR DESCRIPTION
http://crbug.com/472339: DevTools: provide affordance during recording.

Added a css class called ‘pulse’ which has a css animation keyframe
associated with it called ‘pulse-effect’. The class is being added to
the recordButton in NetworkPanel.js in order to keep the pulse effect
limited to only the record button in Network Tab.