### PR TITLE
DevTools: Adjust dev docs for yapf inclusion and correctness

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,11 @@ In addition, you no longer need to pass double dashes (e.g. `--`) before you pas
 #### `npm run format` 
 Formats your code using clang-format
 
+### `npm run format-py`
+Formats your Python code using [yapf](https://github.com/google/yapf)
+
+> Note: Yapf is a command line tool. You will have to install this manually, either from PyPi through `pip install yapf` or if you want to enable multiprocessing in Python 2.7, `pip install futures`
+
 #### `npm test`
 Builds devtools and runs all inspector/devtools layout tests.
 

--- a/scripts/hosted_mode/server.js
+++ b/scripts/hosted_mode/server.js
@@ -17,7 +17,7 @@ http.createServer(requestHandler).listen(serverPort);
 console.log(`Started hosted mode server at http://localhost:${serverPort}\n`);
 console.log('For info on using the hosted mode server, see our contributing docs:');
 console.log('https://bit.ly/devtools-contribution-guide');
-console.log('Tip: Look for the \'Hosted Mode Server Options\' section\n');
+console.log('Tip: Look for the \'Development server options\' section\n');
 
 function requestHandler(request, response) {
   var filePath = parseURL(request.url).pathname;


### PR DESCRIPTION
Adds section about running yapf and fixed typo in
scripts/hosted_mode/server.js to reflect the right name.

https://codereview.chromium.org/2656343003/