### PR TITLE
improve styles (indentation and spacing) on parsed request fields

### DIFF
--- a/front_end/network/requestHeadersTree.css
+++ b/front_end/network/requestHeadersTree.css
@@ -25,6 +25,9 @@
 
 .tree-outline li:not(.parent) {
     margin-left: 10px;
+    margin-right: 10px;
+    padding-left: .5em;
+    text-indent: -.5em;
 }
 
 .tree-outline li:not(.parent)::before {


### PR DESCRIPTION
**Network** > **Headers** already contains a stylized version of the original source, with the fields labeled and bolded.  This seems like an improved way to help keep that information at a high level, based off the [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent) css method [described here](https://stackoverflow.com/a/17158366/1366033).  [Compatible across all browsers (even though only relevant in chrome)](https://caniuse.com/#feat=css-text-indent)

![image](https://user-images.githubusercontent.com/4307307/34793824-ab4d7fe2-f61a-11e7-9790-ae34965c7c7f.png)
