### PR TITLE
Host.InspectorFrontendHostStub  close method don't release memory

### DIFF
--- a/front_end/host/InspectorFrontendHost.js
+++ b/front_end/host/InspectorFrontendHost.js
@@ -200,8 +200,10 @@ Host.InspectorFrontendHostStub = class {
     const link = createElement('a');
     link.download = fileName;
     const blob = new Blob([buffer.join('')], {type: 'text/plain'});
-    link.href = URL.createObjectURL(blob);
+    const blobUrl = URL.createObjectURL(blob);
+    link.href = blobUrl;
     link.click();
+    URL.revokeObjectURL(blobUrl);
   }
 
   /**


### PR DESCRIPTION
Host.InspectorFrontendHostStub  close method don't release memory after call createObjectURL API when user save action

