### PR TITLE
Fix: DOM.setChildNodes missing trigger update event

### DIFF
--- a/front_end/sdk/DOMModel.js
+++ b/front_end/sdk/DOMModel.js
@@ -1395,6 +1395,8 @@ SDK.DOMModel = class extends SDK.SDKModel {
 
     const parent = this._idToDOMNode[parentId];
     parent._setChildrenPayload(payloads);
+    this.dispatchEventToListeners(SDK.DOMModel.Events.NodeInserted, parent);
+    this._scheduleMutationEvent(parent);
   }
 
   /**


### PR DESCRIPTION
I found a problem that the child nodes of a node didn't display in *Elements* after frontend received an event *DOM.setChildNodes*.
I think it may be a small bug which could be caused by the *setChildNodes* function doesn't dispatch event to listeners like other functions in *DOM* domain.
I tested it worked for me. Is this the best way to fix?