### PR TITLE
Show title tooltips for request timing metrics

### DIFF
--- a/front_end/network/RequestTimingView.js
+++ b/front_end/network/RequestTimingView.js
@@ -291,7 +291,9 @@ Network.RequestTimingView = class extends UI.VBox {
       const isTotal = serverTiming.metric.toLowerCase() === 'total';
       const tr = tableElement.createChild('tr', isTotal ? 'network-timing-footer' : '');
       const metric = tr.createChild('td', 'network-timing-metric');
-      metric.createTextChild(serverTiming.description || serverTiming.metric);
+      const description = serverTiming.description || serverTiming.metric;
+      metric.createTextChild(description);
+      metric.title = description;
       const row = tr.createChild('td').createChild('div', 'network-timing-row');
 
       if (serverTiming.value === null)


### PR DESCRIPTION
Since custom Server-Timing header can have long metrics and they can be truncated. This PR adds a title prop so the tooltips make the long names readable.

e.g

![image](https://user-images.githubusercontent.com/1018196/63375661-0ffc6300-c341-11e9-8240-22cc3415d896.png)

I know this repo doesn't merge PRs but would be nice to get a validation pass if anyone is against this. I will figure out how to make a chromium PR and send it there. 
