### PR TITLE
fix: update .npmignore to remove "third_party"

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ PRESUBMIT.py
 OWNERS
 ENG_REVIEW_OWNERS
 
-third_party
 test
 htaccess
 v8/include


### PR DESCRIPTION
A recent update made `chrome-devtools-frontend` no longer work because it's missing some third-party dependencies in the `third_party` directory. Here are the steps to reproduce:

```shell
mkdir temp
cd temp
npm init --yes
npm install --save chrome-devtools-frontend
cd node_modules/chrome-devtools-frontend/front_end
python2.7 -m SimpleHTTPServer
```

Then navigate to http://localhost:8000/inspector.html and click the "Performance" tab. If you open the DevTools on the DevTools themselves, you'll see several failed requests, including for `codemirror.js` which is in the `third_party` directory.

![Screen Shot 2020-08-07 at 10 17 39 AM](https://user-images.githubusercontent.com/283842/89671130-4a834680-d897-11ea-9220-8035c9bcf9e8.png)

Since these files are in GitHub but not in npm (e.g. see [unpkg](http://unpkg.com/chrome-devtools-frontend/)), the issue seems to be the `.npmignore`.