### PR TITLE
Rename "Headers" tab to "Request" tab

### DIFF
--- a/front_end/network/NetworkItemView.js
+++ b/front_end/network/NetworkItemView.js
@@ -60,7 +60,7 @@ export class NetworkItemView extends UI.TabbedPane.TabbedPane {
 
     this._headersView = new RequestHeadersView(request);
     this.appendTab(
-        Tabs.Headers, Common.UIString.UIString('Headers'), this._headersView,
+        Tabs.Headers, Common.UIString.UIString('Request'), this._headersView,
         Common.UIString.UIString('Headers and request body'));
 
     this.addEventListener(UI.TabbedPane.Events.TabSelected, this._tabSelected, this);


### PR DESCRIPTION
I imagine this change is more complex than this trivial PR, but I am hoping this can serve as a jumping off point. Can this tab be renamed "Request". The "Headers" name is confusing since it contains much more information than the request other than headers.