### PR TITLE
Omit default method GET from copy fetch command

### DIFF
--- a/front_end/panels/network/NetworkLogView.ts
+++ b/front_end/panels/network/NetworkLogView.ts
@@ -1896,7 +1896,7 @@ export class NetworkLogView extends UI.Widget.VBox implements
       referrer,
       referrerPolicy,
       body: requestBody,
-      method: request.requestMethod,
+      method: request.requestMethod !== 'GET' ? request.requestMethod : void 0,
       mode: 'cors',
     };
 


### PR DESCRIPTION
Browser's `fetch` uses 'GET' by default. This fix omits default parameter and reduce output command.