### PR TITLE
Cross browser devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "ts_library-test": "./third_party/typescript/tests/verify_ts_libary.sh",
     "unittest": "scripts/test/run_unittests.py --no-text-coverage",
     "watch": "third_party/node/node.py --output scripts/watch_build.js"
+  },
+  "devDependencies": {
+    "sync-fetch": "latest"
   }
 }

--- a/scripts/build/generate_css_js_files.js
+++ b/scripts/build/generate_css_js_files.js
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 const fs = require('fs');
 const path = require('path');
+const fetch = require('sync-fetch');
 const CleanCSS = require('clean-css');
 const [, , isDebugString, targetName, srcDir, targetGenDir, files] = process.argv;
 
@@ -11,6 +12,8 @@ const configFiles = [];
 const cleanCSS = new CleanCSS();
 const isDebug = isDebugString === 'true';
 
+const constructibleStyleSheetsPolyfill = fetch('https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js').text();
+
 for (const fileName of filenames) {
   let output = fs.readFileSync(path.join(srcDir, fileName), {encoding: 'utf8', flag: 'r'});
   output = output.replace(/\`/g, '\\\'');
@@ -18,9 +21,12 @@ for (const fileName of filenames) {
 
   fs.writeFileSync(
       path.join(targetGenDir, fileName + '.js'),
-      `// Copyright ${new Date().getFullYear()} The Chromium Authors. All rights reserved.
+      `${constructibleStyleSheetsPolyfill}
+ 
+// Copyright ${new Date().getFullYear()} The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 const styles = new CSSStyleSheet();
 styles.replaceSync(
 \`${isDebug ? output : cleanCSS.minify(output).styles}


### PR DESCRIPTION
I'm sorry this will probably be the stupidest PR you see this year, but I want the wonderful devtools-frontend to be able to work in Firefox and Safari. Currently [it does not](https://bugs.chromium.org/p/chromium/issues/detail?id=1198904#c_ts1618401530).

There may be lots of work to get this ready, and I'm sure this will seem like a highly stupid, useless and unimportant change to implement for the Chrome team because this is **Chrome** devtools-frontend afterall.

This PR tracks work regarding that.

The first change involved adding a [polyfill for constructible stylesheets](https://github.com/calebdwilliams/construct-style-sheets) as `new CSSStyleSheet` [does not work in Firefox or Safari](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet#browser_compatibility). It may be possible to revert this polyfill addition in future, as [Firefox might be implementing this API](https://bugzilla.mozilla.org/show_bug.cgi?id=1520690).

devtools-frontend uses constructible stylesheets and they appear in the generated CSS JavaScript files. The following is an example, the first few lines of `devtools/Images/Images.js`:

```js
// Copyright 2021 The Chromium Authors. All rights reserved.
// Use of this source code is governed by a BSD-style license that can be
// found in the LICENSE file.
const sheet = new CSSStyleSheet();
sheet.replaceSync(':root {}');
const style = sheet.cssRules[0].style;

style.setProperty('--image-file-accelerometer-bottom', 'url(' + new URL('./accelerometer-bottom.png', import.meta.url).toString() + ')');
```

These are the types of non-cross-browsers APIs that are currently blocking devtools-frontend from working cross-browser.

I'm sure you folks are incredibly busy as well, so I totally get if you're too busy to look at this or if anything else makes it impossible for you, and no worries at all, just thanks for reading this far!