### PR TITLE
Replace US/Pacific with America/Los_Angeles timezone.

### DIFF
--- a/front_end/panels/sensors/sensors-meta.ts
+++ b/front_end/panels/sensors/sensors-meta.ts
@@ -184,7 +184,7 @@ Common.Settings.registerSettingExtension({
       title: 'Mountain View',
       lat: 37.386052,
       long: -122.083851,
-      timezoneId: 'US/Pacific',
+      timezoneId: 'America/Los_Angeles',
       locale: 'en-US',
     },
     {
@@ -198,7 +198,7 @@ Common.Settings.registerSettingExtension({
       title: 'San Francisco',
       lat: 37.774929,
       long: -122.419416,
-      timezoneId: 'US/Pacific',
+      timezoneId: 'America/Los_Angeles',
       locale: 'en-US',
     },
     {


### PR DESCRIPTION
US/Pacific is a (deprecated) alias for the America/Los_Angeles
timezone, which is the canonical location-based timezone name
for Pacific time as it is observed in the US.

---

I am sorry, kind of, for this very silly and trivial changeset and will not feel at all bad if it is immediately closed. Thank you for allowing me to waste some tiny amount of your time 