### PR TITLE
add parsed font-weight value to highlight-overlay card

### DIFF
--- a/inspector_overlay/tool_highlight.ts
+++ b/inspector_overlay/tool_highlight.ts
@@ -490,8 +490,9 @@ export function createElementDescription(elementInfo: ElementInfo, colorFormat: 
 
   const fontFamily = style['font-family'];
   const fontSize = style['font-size'];
-  if (fontFamily && fontSize !== '0px') {
-    addTextRow('Font', `${fontSize} ${fontFamily}`);
+  const fontWeight = style['font-weight'];
+  if (fontFamily && fontWeight && fontSize !== '0px') {
+    addTextRow('Font', `${fontSize} ${fontWeight} ${fontFamily}`);
   }
 
   const bgColor = style['background-color'];


### PR DESCRIPTION
**Hi everyone!**

I suggest adding the `font-weight` value  (bold, thin, 400, 500, 900) to the highlight-overlay card if available in styles.
something like this:
![image](https://github.com/ChromeDevTools/devtools-frontend/assets/29090227/ae447fbf-8b0d-4caa-b399-2e100f498755)
It will help us to see immediately the `font-weight` inline without additional clicks to get the Computed-styles tab.

