### PR TITLE
fix: update network overview only once per frame

### DIFF
--- a/front_end/panels/network/NetworkOverview.ts
+++ b/front_end/panels/network/NetworkOverview.ts
@@ -17,6 +17,7 @@ const coordinator = Coordinator.RenderCoordinator.RenderCoordinator.instance();
 export class NetworkOverview extends PerfUI.TimelineOverviewPane.TimelineOverviewBase {
   private selectedFilmStripTime: number;
   private numBands: number;
+  private updateScheduled: boolean;
   private highlightedRequest: SDK.NetworkRequest.NetworkRequest|null;
   private loadEvents!: number[];
   private domContentLoadedEvents!: number[];
@@ -32,7 +33,7 @@ export class NetworkOverview extends PerfUI.TimelineOverviewPane.TimelineOvervie
     super();
     this.selectedFilmStripTime = -1;
     this.element.classList.add('network-overview');
-
+    this.updateScheduled = false;
     this.numBands = 1;
     this.highlightedRequest = null;
 
@@ -139,13 +140,15 @@ export class NetworkOverview extends PerfUI.TimelineOverviewPane.TimelineOvervie
   }
 
   scheduleUpdate(): void {
-    if (!this.isShowing()) {
+    if (this.updateScheduled || !this.isShowing()) {
       return;
     }
+    this.updateScheduled = true;
     void coordinator.write(this.update.bind(this));
   }
 
   override update(): void {
+    this.updateScheduled = false;
     const calculator = this.calculator();
 
     const newBoundary = new NetworkTimeBoundary(calculator.minimumBoundary(), calculator.maximumBoundary());


### PR DESCRIPTION
See https://bugs.chromium.org/p/chromium/issues/detail?id=1447912

I haven't tested this, but I'm 90% sure this works 