### PR TITLE
Fix Node build hooks on Apple Silicon

### DIFF
--- a/third_party/emscripten-releases/.emscripten
+++ b/third_party/emscripten-releases/.emscripten
@@ -1,12 +1,20 @@
 import os
 import platform
+import subprocess
 import sys
+
+def get_mac_architecture():
+    if platform.machine() == "x86_64":
+        is_translated = subprocess.run(["sysctl", "-n", "sysctl.proc_translated"], capture_output=True, text=True).stdout.strip() == "1"
+        return "arm64" if is_translated else "x86_64"
+    return platform.machine()
 
 emscripten_releases = os.path.abspath(os.path.dirname(
     os.path.dirname(os.path.dirname(sys.argv[0]))))
 NODE_JS = os.path.join(
     os.path.dirname(emscripten_releases), 'node', *{
-        'Darwin': ('mac', 'node-darwin-x64', 'bin', 'node'),
+        'Darwin': ('mac', 'node-darwin-arm64' if get_mac_architecture()
+                       == 'arm64' else 'node-darwin-x64', 'bin', 'node'),
         'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
         'Windows': ('win', 'node.exe'),
     }[platform.system()])

--- a/third_party/node/node.py
+++ b/third_party/node/node.py
@@ -9,11 +9,16 @@ import subprocess
 import sys
 import os
 
+def get_mac_architecture():
+    if platform.machine() == "x86_64":
+        is_translated = subprocess.run(["sysctl", "-n", "sysctl.proc_translated"], capture_output=True, text=True).stdout.strip() == "1"
+        return "arm64" if is_translated else "x86_64"
+    return platform.machine()
 
 def GetBinaryPath():
     return os_path.join(
         os_path.dirname(__file__), *{
-            'Darwin': ('mac', 'node-darwin-arm64' if platform.machine()
+            'Darwin': ('mac', 'node-darwin-arm64' if get_mac_architecture()
                        == 'arm64' else 'node-darwin-x64', 'bin', 'node'),
             'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
             'Windows': ('win', 'node.exe'),


### PR DESCRIPTION
`gclient runhooks` was failing on my Apple Silicon machine because the Python scripts wrapping Node were failing under Rosetta. With this change the hooks ran successfully.