### PR TITLE
POC: capture script attribution data passed via `performance.mark`

### DIFF
--- a/front_end/models/trace/handlers/UserTimingsHandler.ts
+++ b/front_end/models/trace/handlers/UserTimingsHandler.ts
@@ -15,6 +15,7 @@ import {HandlerState} from './types.js';
 let syntheticEvents: Types.Events.SyntheticEventPair<Types.Events.PairableAsync>[] = [];
 const performanceMeasureEvents: Types.Events.PerformanceMeasure[] = [];
 const performanceMarkEvents: Types.Events.PerformanceMark[] = [];
+const performanceAttributionEvents: Types.Events.PerformanceAttribution[] = [];
 
 const consoleTimings: (Types.Events.ConsoleTimeBegin|Types.Events.ConsoleTimeEnd)[] = [];
 
@@ -42,6 +43,12 @@ export interface UserTimingsData {
    * https://developer.mozilla.org/en-US/docs/Web/API/console/timeStamp
    */
   timestampEvents: readonly Types.Events.TimeStamp[];
+
+  /**
+   * Attribution events triggered with the performance.mark() API
+   * https://developer.mozilla.org/en-US/docs/Web/API/Performance/attribution
+   */
+  performanceAttributionEvents: readonly Types.Events.PerformanceAttribution[];
 }
 let handlerState = HandlerState.UNINITIALIZED;
 
@@ -49,6 +56,7 @@ export function reset(): void {
   syntheticEvents.length = 0;
   performanceMeasureEvents.length = 0;
   performanceMarkEvents.length = 0;
+  performanceAttributionEvents.length = 0;
   consoleTimings.length = 0;
   timestampEvents.length = 0;
   handlerState = HandlerState.INITIALIZED;
@@ -157,6 +165,10 @@ export function handleEvent(event: Types.Events.Event): void {
   }
   if (Types.Events.isPerformanceMark(event)) {
     performanceMarkEvents.push(event);
+
+    if (Types.Events.isPerformanceAttribution(event)) {
+      performanceAttributionEvents.push(event);
+    }
   }
   if (Types.Events.isConsoleTime(event)) {
     consoleTimings.push(event);
@@ -189,5 +201,6 @@ export function data(): UserTimingsData {
     // TODO(crbug/41484172): UserTimingsHandler.test.ts fails if this is not copied.
     performanceMarks: [...performanceMarkEvents],
     timestampEvents: [...timestampEvents],
+    performanceAttributionEvents: [...performanceAttributionEvents],
   };
 }

--- a/front_end/models/trace/handlers/UserTimingsHandler.ts
+++ b/front_end/models/trace/handlers/UserTimingsHandler.ts
@@ -48,7 +48,7 @@ export interface UserTimingsData {
    * Attribution events triggered with the performance.mark() API
    * https://developer.mozilla.org/en-US/docs/Web/API/Performance/attribution
    */
-  performanceAttributionEvents: readonly Types.Events.PerformanceAttribution[];
+  performanceAttributions: readonly Types.Events.PerformanceAttribution[];
 }
 let handlerState = HandlerState.UNINITIALIZED;
 
@@ -201,6 +201,6 @@ export function data(): UserTimingsData {
     // TODO(crbug/41484172): UserTimingsHandler.test.ts fails if this is not copied.
     performanceMarks: [...performanceMarkEvents],
     timestampEvents: [...timestampEvents],
-    performanceAttributionEvents: [...performanceAttributionEvents],
+    performanceAttributions: [...performanceAttributionEvents],
   };
 }

--- a/front_end/models/trace/types/TraceEvents.ts
+++ b/front_end/models/trace/types/TraceEvents.ts
@@ -95,6 +95,7 @@ export interface ArgsData {
   url?: string;
   navigationId?: string;
   frame?: string;
+  attribution?: string;
 }
 
 export interface CallFrame {
@@ -1287,9 +1288,7 @@ export interface PerformanceMark extends UserTiming {
 export interface PerformanceAttribution extends UserTiming {
   args: Args&{
     data: ArgsData & {
-      src: string,
-      slug: string,
-      name: string,
+      detail: string,
     },
   };
 }

--- a/front_end/models/trace/types/TraceEvents.ts
+++ b/front_end/models/trace/types/TraceEvents.ts
@@ -1284,6 +1284,16 @@ export interface PerformanceMark extends UserTiming {
   ph: Phase.INSTANT|Phase.MARK|Phase.ASYNC_NESTABLE_INSTANT;
 }
 
+export interface PerformanceAttribution extends UserTiming {
+  args: Args&{
+    data: ArgsData & {
+      src: string,
+      slug: string,
+      name: string,
+    },
+  };
+}
+
 export interface ConsoleTimeBegin extends PairableAsyncBegin {
   cat: 'blink.console';
 }
@@ -2130,6 +2140,10 @@ export function isPerformanceMeasure(event: Event): event is PerformanceMeasure 
 
 export function isPerformanceMark(event: Event): event is PerformanceMark {
   return isUserTiming(event) && (event.ph === Phase.MARK || event.ph === Phase.INSTANT);
+}
+
+export function isPerformanceAttribution(event: Event): event is PerformanceAttribution {
+  return event.name.startsWith('attribution::');
 }
 
 export function isConsoleTime(event: Event): event is ConsoleTime {

--- a/front_end/panels/freestyler/AiAgent.ts
+++ b/front_end/panels/freestyler/AiAgent.ts
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import * as Host from '../../core/host/host.js';
+import { TimelineUIUtils } from '../timeline/TimelineUIUtils.js';
 
 export const enum ResponseType {
   CONTEXT = 'context',
@@ -373,6 +374,17 @@ STOP`;
     for await (const response of this.handleContextDetails(options.selected)) {
       this.#addHistory(id, response);
       yield response;
+    }
+
+    // Potentially enhance the query with Attribution context.
+    if (options.selected?.selectedNode?.id === 'EvaluateScript' || options.selected?.selectedNode?.id === 'CompileScript') {
+      const url = options.selected?.selectedNode?.event?.args?.data?.url;
+      if (url) {
+        const attribution = TimelineUIUtils.getAttributionForUrl(url, [...options.selected.parsedTrace.UserTimings.performanceAttributions]);
+        if (attribution) {
+          query = `${query}\n\nNote:Attribution for this source: ${attribution}`;
+        }
+      }
     }
 
     query = await this.enhanceQuery(query, options.selected);

--- a/front_end/panels/timeline/TimelineUIUtils.ts
+++ b/front_end/panels/timeline/TimelineUIUtils.ts
@@ -570,6 +570,10 @@ const UIStrings = {
    *@description Text for a WordPress plugin attribution
    */
   wordpressPlugin: 'WordPress Plugin',
+  /**
+   *@description Text for a WordPress theme attribution
+   */
+  wordpressTheme: 'WordPress Theme',
 };
 const str_ = i18n.i18n.registerUIStrings('panels/timeline/TimelineUIUtils.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -1745,7 +1749,17 @@ export class TimelineUIUtils {
     });
     if (attribution) {
       const detail = JSON.parse(attribution.args.data.detail);
-      return 'core' === detail.slug ? i18nString(UIStrings.wordpressCore) : i18nString(UIStrings.wordpressPlugin) + ' - ' + detail.name;
+
+      // Determine the type of attribution is based on the attribution name. It can be either a plugin, theme or core enqueue.
+      let type = '';
+      if (attribution.name.includes('core')) {
+        type = UIStrings.wordpressCore;
+      } else if (attribution.name.includes('plugin')) {
+        type = UIStrings.wordpressPlugin;
+      } else if (attribution.name.includes('theme')) {
+        type = UIStrings.wordpressTheme;
+      }
+      return `${type} - ${detail.name}`;
     }
     return null;
   }

--- a/front_end/panels/timeline/TimelineUIUtils.ts
+++ b/front_end/panels/timeline/TimelineUIUtils.ts
@@ -1733,10 +1733,10 @@ export class TimelineUIUtils {
   /**
    * Get attribution data for a given URL.
    *
-   * @param url URL to check for attribution data.
-   * @param attributions Array of performance attributions. Immutable.
+   * @param {string} url URL to check for attribution data.
+   * @param {Trace.Types.Events.PerformanceAttribution[]} attributions Array of performance attributions. Immutable.
    *
-   * @returns Attribution name or null if no attribution is found.
+   * @return {string|null} Attribution name or null if no attribution is found.
    */
   static getAttributionForUrl(url: string, attributions: Trace.Types.Events.PerformanceAttribution[]): string|null {
     const attribution = attributions.find(attribution => {

--- a/front_end/panels/timeline/TimelineUIUtils.ts
+++ b/front_end/panels/timeline/TimelineUIUtils.ts
@@ -565,7 +565,7 @@ const UIStrings = {
   /**
    *@description Text for a WordPress core attribution
    */
-  wordpressCore: 'Wordpress Core',
+  wordpressCore: 'WordPress Core',
   /**
    *@description Text for a WordPress plugin attribution
    */

--- a/front_end/panels/timeline/TimelineUIUtils.ts
+++ b/front_end/panels/timeline/TimelineUIUtils.ts
@@ -565,7 +565,7 @@ const UIStrings = {
   /**
    *@description Text for a WordPress core attribution
    */
-  wordpressCore: 'WordPress Core',
+  wordpressCore: 'Core',
   /**
    *@description Text for a WordPress plugin attribution
    */

--- a/front_end/panels/timeline/TimelineUIUtils.ts
+++ b/front_end/panels/timeline/TimelineUIUtils.ts
@@ -191,10 +191,7 @@ const UIStrings = {
    *@description Text for a module, the programming concept
    */
   module: 'Module',
-  /**
-   *@description Text for a performance attribution event
-   */
-  attribution: 'Attribution',
+
   /**
    *@description Label for a group of JavaScript files
    */
@@ -561,6 +558,18 @@ const UIStrings = {
    * @description Label for a string that describes the priority at which a task was scheduled, like 'background' for low-priority tasks, and 'user-blocking' for high priority.
    */
   priority: 'Priority',
+  /**
+   *@description Text for a performance attribution event
+   */
+  attribution: 'Attribution',
+  /**
+   *@description Text for a WordPress core attribution
+   */
+  wordpressCore: 'Wordpress Core',
+  /**
+   *@description Text for a WordPress plugin attribution
+   */
+  wordpressPlugin: 'WordPress Plugin',
 };
 const str_ = i18n.i18n.registerUIStrings('panels/timeline/TimelineUIUtils.ts', UIStrings);
 const i18nString = i18n.i18n.getLocalizedString.bind(undefined, str_);
@@ -1731,8 +1740,8 @@ export class TimelineUIUtils {
     });
     if (attribution) {
       const detail = JSON.parse(attribution.args.data.detail);
-      const name = 'core' === detail.slug ? 'Wordpress Core' : 'WordPress Plugin - ' + detail.name;
-      contentHelper.appendTextRow('Attribution', name);
+      const name = 'core' === detail.slug ? i18nString(UIStrings.wordpressCore) : i18nString(UIStrings.wordpressPlugin) + ' - ' + detail.name;
+      contentHelper.appendTextRow(i18nString(UIStrings.attribution), name);
     }
   }
 

--- a/front_end/panels/timeline/TimelineUIUtils.ts
+++ b/front_end/panels/timeline/TimelineUIUtils.ts
@@ -961,7 +961,6 @@ export class TimelineUIUtils {
         const url = unsafeEventData['url'];
         if (url) {
           const {lineNumber} = Trace.Helpers.Trace.getZeroIndexedLineAndColumnForEvent(event);
-          const attribution = TimelineUIUtils.getAttributionForUrl(url, [...parsedTrace.UserTimings.performanceAttributions]);
           details = this.linkifyLocation({
             scriptId: null,
             url,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c32b480e-d7ee-4d6c-8f3b-aa46deb36611)
