### PR TITLE
add sourceUrl content to source infos for parsed source maps

### DIFF
--- a/front_end/core/sdk/SourceMap.ts
+++ b/front_end/core/sdk/SourceMap.ts
@@ -165,7 +165,7 @@ export class SourceMap {
    */
   constructor(
       compiledURL: Platform.DevToolsPath.UrlString, sourceMappingURL: Platform.DevToolsPath.UrlString,
-      payload: SourceMapV3) {
+      payload: SourceMapV3, sourceContent: string) {
     this.#json = payload;
     this.#compiledURLInternal = compiledURL;
     this.#sourceMappingURL = sourceMappingURL;
@@ -178,7 +178,9 @@ export class SourceMap {
             `SourceMap "${sourceMappingURL}" contains unsupported "URL" field in one of its sections.`);
       }
     }
-    this.eachSection(this.parseSources.bind(this));
+    this.eachSection((sourceMapObject: SourceMapV3Object) => {
+      this.parseSources(sourceMapObject, sourceContent);
+    });
   }
 
   compiledURL(): Platform.DevToolsPath.UrlString {
@@ -439,7 +441,7 @@ export class SourceMap {
     }
   }
 
-  private parseSources(sourceMap: SourceMapV3Object): void {
+  private parseSources(sourceMap: SourceMapV3Object, sourceContent: string): void {
     const sourceRoot = sourceMap.sourceRoot ?? '';
     const ignoreList = new Set(sourceMap.ignoreList ?? sourceMap.x_google_ignoreList);
     for (let i = 0; i < sourceMap.sources.length; ++i) {
@@ -458,7 +460,7 @@ export class SourceMap {
       }
       const url =
           Common.ParsedURL.ParsedURL.completeURL(this.#baseURL, href) || (href as Platform.DevToolsPath.UrlString);
-      const source = sourceMap.sourcesContent && sourceMap.sourcesContent[i];
+      const source = sourceMap.sourcesContent && sourceMap.sourcesContent[i] || sourceContent;
       const sourceInfo: SourceInfo = {
         sourceURL: url,
         content: source ?? null,


### PR DESCRIPTION
While [`sourceContent` is an optional source map field](https://tc39.es/ecma426/#:~:text=sourcesContent%20is%20an%20optional%20list%20of%20source%20content), it is required for certain behaviors since it is [the only field that is used](https://github.com/vzaidman/devtools-frontend/blob/3b8378e6ae4b16481d5d8dc7e3c72dc08124446a/front_end/core/sdk/SourceMap.ts#L700-L714) to populate `#sourceInfos`/`#sourceInfoByURL` that serves as a source-map-to-source-content reference for source maps.

This creates issues with legitimate source maps that omit `sourceContent` (again, it's an optional field) and provide `source` urls instead.

E.G. we had this hot reload issue on React Native: https://github.com/facebook/react-native/issues/49069 that [was just fixed](https://github.com/facebook/metro/commit/cd7a93557453ff3c36e367ef7a049471f1fbe182?fbclid=IwZXh0bgNhZW0CMTEAAR1ozJ6ji3ysFWy0sUXgMs2AgXzcCpPg5EqE_A2t6n-TYef7mL4jOoFKOMw_aem_NBgiNVp7Yic3f1d4U6F-bg).

It was caused by the code that [checks if source maps are compatible with each other](https://github.com/facebookexperimental/rn-chrome-devtools-frontend/blob/main/front_end/core/sdk/SourceMap.ts#L821). That code is failing to recognize that the new source map is incompatible with the old, unless `sourceContent` is provided, thus **[adding source maps for files instead of replacing them](https://github.com/facebookexperimental/rn-chrome-devtools-frontend/blob/ca9417cf91bf6a388eeb1915e4bd97fd9afe0a42/front_end/models/bindings/CompilerScriptMapping.ts#L425)** for files **with different source code**.

Minimum reproduction: https://github.com/vzaidman/simple-hot-reload-website

I don't have the context on what's the full correct solution, but essentially, I think `#sourceInfos`/`#sourceInfoByURL` should be populated with the contents of source files fetched from `sources` if `sourceContent` is missing. This PR is the initial draft for that.